### PR TITLE
Fix react-native fetch

### DIFF
--- a/src/handlers/RequestHandler.js
+++ b/src/handlers/RequestHandler.js
@@ -9,7 +9,9 @@
 
 var ResponseHandler = require('./ResponseHandler');
 require('es6-promise').polyfill();
-require('isomorphic-fetch');
+if(typeof fetch === 'undefined') {
+  require('isomorphic-fetch');
+}
 
 function RequestHandler(vals, endpoint, cb) {
 


### PR DESCRIPTION
Importing `isomorphic-fetch` pollutes the global scope when `fetch` is already defined. Therefore, check if `fetch` is defined and dynamically import `isomorphic-fetch` if not.
PR for #22.